### PR TITLE
SP-1931: Create a mockup landing page for the RSP

### DIFF
--- a/data/landing_page.md
+++ b/data/landing_page.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1493c35a410dbccf820311e1af97eea516dbf477f2393311c4915ecd77f06b46
+size 1595

--- a/data/landing_page.md
+++ b/data/landing_page.md
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fe470d24b0b7b6b2562b58333be2113cd82a6a59b5bbd4ebab3143e711ff831
-size 1545
+oid sha256:676df49cb5ad7238b841cf3c0be3fb3faf7ff6f44c151adacfdea4a41946b888
+size 1486

--- a/data/landing_page.md
+++ b/data/landing_page.md
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1493c35a410dbccf820311e1af97eea516dbf477f2393311c4915ecd77f06b46
-size 1595
+oid sha256:1fe470d24b0b7b6b2562b58333be2113cd82a6a59b5bbd4ebab3143e711ff831
+size 1545


### PR DESCRIPTION
Edited in response to comments from https://github.com/lsst/tutorial-notebooks/pull/22, and moved to this repo to allow for the logo to be co-located with the .md file.