### PR TITLE
SP-2931: Add a CMD plot json file 

### DIFF
--- a/data/dp1_311_4_CMD.json
+++ b/data/dp1_311_4_CMD.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ab5946bbf9a76b50936f5b35a6ebbb5af9ee453d80095c34b20fe514bae7c28
+size 3269575


### PR DESCRIPTION
This pre-created, 3.3 MB JSON file is used in Notebook Tutorial 311.4 to demonstrate how to enhance JSON-based visualizations.